### PR TITLE
authentication-middleware: repo url now using organization attribute

### DIFF
--- a/recipes/authentication_middleware.rb
+++ b/recipes/authentication_middleware.rb
@@ -15,7 +15,7 @@ end
 git '/opt/ernest-libraries/authentication-middleware' do
   user node['server']['user']
   group node['server']['group']
-  repository 'git@github.com:ernestio/authentication-middleware.git'
+  repository "git@github.com:#{node['ernest']['organization']}/authentication-middleware.git"
   revision rev
   action :sync
 end


### PR DESCRIPTION
authentication-middleware recipe was not using the global organization attribute on its url, now it is fixed.