### PR TITLE
[WIP] : Use nat-all-aws-connector instead of one per subject

### DIFF
--- a/attributes/ernest.rb
+++ b/attributes/ernest.rb
@@ -47,24 +47,7 @@ default['ernest']['services']['gpb'] = {
   'api-gateway' => { org: 'ernestio', version: node['ernest']['version'] },
   'vcloud-definition-mapper' => { org: 'ernestio', version: node['ernest']['version'] },
   'aws-definition-mapper' => { org: 'ernestio', version: node['ernest']['version'] },
-  'network-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'network-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'firewall-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'firewall-updater-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'firewall-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'nat-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'nat-updater-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'nat-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'vpc-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'vpc-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'instance-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'instance-updater-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'instance-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'elb-creator-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'elb-updater-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'elb-deleter-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  's3-all-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] },
-  'route53-all-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] }
+  'all-all-aws-connector' => { org: 'ernestio', version: node['ernest']['version'] }
 }
 
 default['ernest']['services']['vcloud'] = {

--- a/templates/ernestenv.sh.erb
+++ b/templates/ernestenv.sh.erb
@@ -6,3 +6,4 @@ export NATS_URI=<%= @nats_uri %>
 <% if ['dev', 'test'].include? @env %>
 export NATS_URI_TEST=<%= @nats_uri_test %>
 <% end %>
+export CONNECTORS=nat.create.aws,nat.update.aws,nat.delete.aws,network.create.aws,network.delete.aws,route53.create.aws,route53.delete.aws,route53.update.aws,s3.create.aws,s3.update.aws,s3.delete.aws,elb.create.aws,elb.delete.aws,elb.update.aws,vpc.create.aws,vpc.delete.aws,instance.delete.aws,instance.update.aws,instance.create.aws,firewall.create.aws,firewall.update.aws,firewall.delete.aws,ebs.create.aws,ebs.update.aws,ebs.delete.aws


### PR DESCRIPTION
Fixes [this](https://github.com/ernestio/ernest/issues/139) by merging all nat-*-aws-connectors on a single [nat-all-aws-connector](https://github.com/ernestio/nat-all-aws-connector) service